### PR TITLE
Fix recursive dependency conflict

### DIFF
--- a/jwtap.rb
+++ b/jwtap.rb
@@ -5,9 +5,9 @@ class Jwtap < Formula
   url 'https://github.com/DaveWillkomm/jwtap/archive/v1.1.0.tar.gz'
   sha256 '85543543ac67e0b8c9332a3ac3e5075a6c46a63fdeecb144723a672b74289421'
 
-  depends_on 'openssl'
+  depends_on 'openssl@1.1'
   depends_on 'pcre'
-  depends_on 'wget'
+  depends_on 'wget' => :build
 
   def install
     ohai 'Building Nginx + ngx_mruby + mruby-jwt (this may take some time)'


### PR DESCRIPTION
wget depends on openssl@1.1, so I had to update this formula to do the same. Something about this feels wrong to me, but I poked around a little bit but don't want to spend more time on it. Like why doesn't a specific version take precedence over a non-version specified dependency? Also why is this an issue if Homebrew can install both versions of openssl at the same time? It seems it treats them as totally different entities in that the "@1.1" is part of the name, rather than a version number that is meta data.